### PR TITLE
Add Firebase auth and Firestore utilities

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,20 +4,23 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ChatScreen from './screens/ChatScreen';
 import { RevenueCatProvider } from './utils/RevenueCatProvider';
 import { AdsProvider } from './utils/AdsProvider';
+import { AuthProvider } from './context/AuthContext';
 import './utils/firebase';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <RevenueCatProvider>
-      <AdsProvider>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen name="Chat" component={ChatScreen} />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </AdsProvider>
-    </RevenueCatProvider>
+    <AuthProvider>
+      <RevenueCatProvider>
+        <AdsProvider>
+          <NavigationContainer>
+            <Stack.Navigator>
+              <Stack.Screen name="Chat" component={ChatScreen} />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </AdsProvider>
+      </RevenueCatProvider>
+    </AuthProvider>
   );
 }

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { User } from 'firebase/auth';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../utils/firebase';
+
+interface AuthContextValue {
+  user: User | null;
+}
+
+// Christ-centered auth context offering the current anonymous user
+const AuthContext = createContext<AuthContextValue>({ user: null });
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+
+  useEffect(() => {
+    // Listen for authentication state to persist the user across sessions
+    const unsubscribe = onAuthStateChanged(auth, setUser);
+    return unsubscribe;
+  }, []);
+
+  return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>;
+};
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (ctx === undefined) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/utils/firebase.ts
+++ b/utils/firebase.ts
@@ -1,23 +1,21 @@
-// utils/firebase.ts
-
+// Firebase initialization for the WWJD app
 import { initializeApp } from 'firebase/app';
 import { getAuth, signInAnonymously } from 'firebase/auth';
 
-// Firebase config — safe to store directly for client-side use
+// Safe to expose in client code
 const firebaseConfig = {
   apiKey: 'AIzaSyDHT55zZ4X3XnbNcqjfFdlHrkc-TUbZXME',
   authDomain: 'wwjd-app-188fe.firebaseapp.com',
   projectId: 'wwjd-app-188fe',
-  storageBucket: 'wwjd-app-188fe.appspot.com', // fixed typo (.app → .appspot.com)
+  storageBucket: 'wwjd-app-188fe.appspot.com',
   messagingSenderId: '721094138400',
   appId: '1:721094138400:web:3e5e1a69e92e26668cba45',
-  measurementId: 'G-ZVH0W24T2G', // Safe to leave in, unused by mobile
 };
 
-// Initialize Firebase App
+// Create the Firebase app instance
 const app = initializeApp(firebaseConfig);
 
-// Auth (anonymous for now)
+// Sign in anonymously so every soul can chat without friction
 const auth = getAuth(app);
 signInAnonymously(auth).catch(console.error);
 

--- a/utils/firestore.ts
+++ b/utils/firestore.ts
@@ -1,0 +1,22 @@
+import { getFirestore, collection, addDoc } from 'firebase/firestore';
+import { app } from './firebase';
+
+// Initialize Firestore with our existing Firebase app
+const db = getFirestore(app);
+
+/**
+ * Persist a message to Firestore so conversations can be revisited.
+ * The timestamp uses the device clock for simplicity.
+ */
+export async function saveMessage(
+  userId: string,
+  text: string,
+  from: 'user' | 'ai'
+): Promise<void> {
+  await addDoc(collection(db, 'messages'), {
+    userId,
+    text,
+    from,
+    timestamp: Date.now(),
+  });
+}


### PR DESCRIPTION
## Summary
- initialize Firebase app with anonymous auth
- add Firestore helper to save chat messages
- provide AuthContext to expose the current user
- wrap the app with AuthProvider

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865932173d883308d8dd11414e1a1c6