### PR TITLE
Improve chat layout with keyboard-safe input

### DIFF
--- a/components/InputBar.tsx
+++ b/components/InputBar.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, StyleSheet } from 'react-native';
+import {
+  View,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+  Platform,
+  SafeAreaView,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 interface Props {
   onSend: (text: string) => void;
@@ -15,30 +23,57 @@ export default function InputBar({ onSend }: Props) {
   };
 
   return (
-    <View style={styles.container}>
-      <TextInput
-        value={text}
-        onChangeText={setText}
-        placeholder="Ask Jesus..."
-        style={styles.input}
-      />
-      <Button title="Send" onPress={handleSend} />
-    </View>
+    <SafeAreaView edges={["bottom"]} style={styles.safeArea}>
+      <View style={styles.container}>
+        <TextInput
+          value={text}
+          onChangeText={setText}
+          placeholder="Ask Jesus..."
+          placeholderTextColor="#999"
+          style={styles.input}
+        />
+        <TouchableOpacity onPress={handleSend} style={styles.sendButton}>
+          <Ionicons name="send" size={20} color="#333" />
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    backgroundColor: '#f5f2ec',
+  },
   container: {
     flexDirection: 'row',
-    padding: 8,
     alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    paddingBottom: Platform.OS === 'android' ? 24 : 8,
+    marginHorizontal: 8,
+    marginBottom: 8,
+    backgroundColor: '#f5f2ec',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: -2 },
+    shadowRadius: 4,
+    elevation: 2,
   },
   input: {
     flex: 1,
     marginRight: 8,
     borderWidth: 1,
     borderColor: '#ccc',
-    borderRadius: 4,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#fff',
+    fontSize: 16,
+  },
+  sendButton: {
     padding: 8,
   },
 });

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -18,15 +18,15 @@ const styles = StyleSheet.create({
   bubble: {
     padding: 10,
     marginVertical: 4,
-    borderRadius: 8,
+    borderRadius: 12,
     maxWidth: '80%',
   },
   ai: {
-    backgroundColor: '#e0e0e0',
+    backgroundColor: '#fff9e5',
     alignSelf: 'flex-start',
   },
   user: {
-    backgroundColor: '#cfe9ff',
+    backgroundColor: '#e0f0ff',
     alignSelf: 'flex-end',
   },
   text: {

--- a/screens/ChatScreen.tsx
+++ b/screens/ChatScreen.tsx
@@ -1,5 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { View, FlatList, SafeAreaView } from 'react-native';
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  View,
+  ScrollView,
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+} from 'react-native';
 import * as Application from 'expo-application';
 import * as Device from 'expo-device';
 import InputBar from '../components/InputBar';
@@ -51,17 +58,46 @@ export default function ChatScreen() {
     }
   };
 
+  const scrollViewRef = useRef<ScrollView>(null);
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <FlatList
-        data={messages}
-        renderItem={({ item }) => (
-          <MessageBubble text={item.text} fromUser={item.fromUser} />
-        )}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={{ padding: 10 }}
-      />
-      <InputBar onSend={sendMessage} />
-    </SafeAreaView>
+    <KeyboardAvoidingView
+      style={styles.wrapper}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={60}
+    >
+      <SafeAreaView style={styles.container}>
+        <ScrollView
+          ref={scrollViewRef}
+          contentContainerStyle={styles.messages}
+          onContentSizeChange={() =>
+            scrollViewRef.current?.scrollToEnd({ animated: true })
+          }
+        >
+          {messages.map((m) => (
+            <MessageBubble
+              key={m.id}
+              text={m.text}
+              fromUser={m.fromUser}
+            />
+          ))}
+        </ScrollView>
+        <InputBar onSend={sendMessage} />
+      </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    backgroundColor: '#fdfaf6',
+  },
+  container: {
+    flex: 1,
+  },
+  messages: {
+    flexGrow: 1,
+    padding: 10,
+  },
+});


### PR DESCRIPTION
## Summary
- revamp InputBar with SafeAreaView, cross-platform shadows and send icon
- wrap ChatScreen in KeyboardAvoidingView and use ScrollView for messages
- restyle message bubbles for a gentle palette

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686737e8f70c83308e329f629b64f003