### PR TITLE
Fix React Navigation id and expo-application usage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
     <RevenueCatProvider>
       <AdsProvider>
         <NavigationContainer>
-          <Stack.Navigator id="root">
+          <Stack.Navigator>
             <Stack.Screen name="Chat" component={ChatScreen} />
           </Stack.Navigator>
         </NavigationContainer>

--- a/screens/ChatScreen.tsx
+++ b/screens/ChatScreen.tsx
@@ -27,7 +27,7 @@ export default function ChatScreen() {
   const { showAd } = useAds();
 
   const registerAnonymousUser = async () => {
-    const androidId = await Application.getAndroidIdAsync();
+    const androidId = Application.androidId;
     const res = await fetch('https://your-api.com/auth/anonymous', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- remove unnecessary `id` prop from `Stack.Navigator`
- use `Application.androidId` to retrieve Android ID

## Testing
- `npx tsc screens/ChatScreen.tsx App.tsx --noEmit --jsx react --target esnext` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f3434f3388330b1ac5790f6a15690