### PR TITLE
Update cloud function URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 OPENAI_API_KEY=sk-fake
 REVENUECAT_API_KEY=rc-fake
+EXPO_PUBLIC_API_BASE=https://askjesus-y54eeumzaq-uc.a.run.app

--- a/services/openai.ts
+++ b/services/openai.ts
@@ -6,7 +6,12 @@ export const askJesus = async (message: string): Promise<string> => {
 
     console.log('Sending message to API:', message);
 
-    const res = await fetch('https://askjesus-54eeuzmaqe-uc.a.run.app', {
+    const baseUrl = process.env.EXPO_PUBLIC_API_BASE;
+    if (!baseUrl) {
+      throw new Error('API base URL not configured');
+    }
+
+    const res = await fetch(baseUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- store API base URL in `.env`
- use `process.env.EXPO_PUBLIC_API_BASE` when calling `askJesus`

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873c7dc80508330900468e31bdfb259