### PR TITLE
Fix Firebase project ID references

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "WWJDApp",
-    "slug": "WWJDApp",
+    "name": "wwjd-app-188fe",
+    "slug": "wwjd-app-188fe",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wwjdapp",
+  "name": "wwjd-app-188fe",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wwjdapp",
+      "name": "wwjd-app-188fe",
       "version": "1.0.0",
       "license": "0BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wwjdapp",
+  "name": "wwjd-app-188fe",
   "license": "0BSD",
   "version": "1.0.0",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- update Expo configuration to use the correct project ID
- update npm metadata to avoid invalid project names
- keep `.firebaserc` pointing at `wwjd-app-188fe`

## Testing
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_687441c79ad083308ccbb3f0f0898bae