### PR TITLE
Revert cloud functions to Gen1

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "20"
+        "node": "18"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
     "deploy": "firebase deploy --only functions"
   },
   "engines": {
-    "node": "20"
+    "node": "18"
   },
   "dependencies": {
     "openai": "^5.10.2",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,4 @@
-import * as functions from 'firebase-functions/v2';
+import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
@@ -46,12 +46,6 @@ app.post('/askJesus', async (req: Request, res: Response) => {
   }
 });
 
-export const askJesus = functions.https.onRequest(
-  {
-    memory: '512MiB',
-    timeoutSeconds: 60,
-  },
-  app
-);
+export const askJesus = functions.https.onRequest(app);
 
 export { generateOpenAI };

--- a/functions/src/openai.ts
+++ b/functions/src/openai.ts
@@ -1,4 +1,3 @@
-import { onCall } from 'firebase-functions/v2/https';
 import * as functions from 'firebase-functions';
 import OpenAI from 'openai';
 
@@ -20,8 +19,8 @@ export async function generateWithOpenAI(prompt: string): Promise<string> {
 
 type OpenAIInput = { prompt?: string };
 
-export const generateOpenAI = onCall<OpenAIInput>(async (request) => {
-  const prompt = request.data.prompt ?? '';
+export const generateOpenAI = functions.https.onCall(async (data, _context) => {
+  const prompt = (data as OpenAIInput).prompt ?? '';
   const result = await generateWithOpenAI(prompt);
   return { result };
 });


### PR DESCRIPTION
## Summary
- switch imports back to `firebase-functions`
- expose `askJesus` using Gen 1 `https.onRequest`
- update `generateOpenAI` to use Gen 1 `https.onCall`
- pin Node.js 18 in `functions/package.json`

## Testing
- `npm --prefix functions install`
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_68827fe596e48330b527382af9c9443f