### PR TITLE
Fix navigation params and update chat screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,11 @@ import ChatScreen from './screens/ChatScreen';
 import { RevenueCatProvider } from './utils/RevenueCatProvider';
 import { AdsProvider } from './utils/AdsProvider';
 
-const Stack = createNativeStackNavigator();
+type RootStackParamList = {
+  Chat: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList, undefined>();
 
 export default function App() {
   return (

--- a/screens/ChatScreen.tsx
+++ b/screens/ChatScreen.tsx
@@ -27,7 +27,7 @@ export default function ChatScreen() {
   const { showAd } = useAds();
 
   const registerAnonymousUser = async () => {
-    const androidId = Application.androidId;
+    const androidId = Application.getAndroidId();
     const res = await fetch('https://your-api.com/auth/anonymous', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- define `RootStackParamList` to specify no route params
- use `Application.getAndroidId()` instead of missing `androidId` property

## Testing
- `npx tsc --noEmit` *(fails: help message)*
- `npm start` *(starts Metro server)*

------
https://chatgpt.com/codex/tasks/task_e_68828f86ea608330bf07fe108ed314b5