### PR TITLE
Improve askJesus endpoint debugging and client error handling

### DIFF
--- a/functions/src/askJesus.ts
+++ b/functions/src/askJesus.ts
@@ -5,41 +5,83 @@ import { JESUS_SYSTEM_TEXT } from "./jesusPrompt";
 const PROJECT_ID = process.env.GCLOUD_PROJECT!;
 const LOCATION = process.env.VERTEX_LOCATION || "us-central1";
 const MODEL = process.env.VERTEX_MODEL || "gemini-2.5-flash";
+const DEBUG = process.env.DEBUG_ASKJESUS === "1";
 
-// Single Vertex client/model, reused across requests.
 const vertex = new VertexAI({ project: PROJECT_ID, location: LOCATION });
 const model = vertex.getGenerativeModel({ model: MODEL });
 
+function sendCors(res: any) {
+  res.set("Access-Control-Allow-Origin", "*");
+  res.set("Access-Control-Allow-Methods", "POST,OPTIONS");
+  res.set("Access-Control-Allow-Headers", "Content-Type,X-Debug");
+}
+
 export const askJesus = onRequest({ cors: true }, async (req, res) => {
+  sendCors(res);
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+
   try {
-    // Handle string or JSON body
-    const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
-    const message: string | undefined = body?.message;
+    // Robust body parsing: JSON, raw text, form, or query.
+    let body: any = req.body;
+    if (typeof body === "string") {
+      try { body = JSON.parse(body); } catch { /* keep string */ }
+    }
+    const fromJson = typeof body === "object" && body ? body.message : undefined;
+    const fromRaw = typeof body === "string" ? body : undefined;
+    const fromQuery = (req.query?.message as string) || undefined;
+    const fromForm = (req as any).files ? undefined : (req as any).body?.message; // best-effort
+
+    const message: string | undefined =
+      fromJson || fromQuery || fromForm || (fromRaw && fromRaw.trim() ? fromRaw : undefined);
+
+    if (DEBUG) {
+      console.log("askJesus DEBUG incoming:", {
+        method: req.method,
+        contentType: req.get("content-type"),
+        hasBody: !!req.body,
+        bodyType: typeof req.body,
+        query: req.query,
+        inferredMessageLen: message?.length ?? 0,
+      });
+    }
+
     if (!message) {
-      res.status(400).json({ error: "Missing 'message'." });
+      res.status(400).json({
+        error: "Missing 'message'. Send JSON { message: string } or ?message=...",
+        hint: {
+          expected: { message: "Hello there" },
+          receivedContentType: req.get("content-type") || null,
+          receivedType: typeof req.body,
+        },
+      });
       return;
     }
 
-    // System instruction is injected from jesusPrompt.ts to ensure the voice
-    const systemInstruction = { role: "system", parts: [{ text: JESUS_SYSTEM_TEXT }] };
+    const systemInstruction = { parts: [{ text: JESUS_SYSTEM_TEXT }] } as any;
 
     const result = await model.generateContent({
       systemInstruction,
       contents: [{ role: "user", parts: [{ text: message }]}],
-      generationConfig: {
-        maxOutputTokens: 768,     // prevent early truncation
-        temperature: 0.7,
-      },
+      generationConfig: { maxOutputTokens: 768, temperature: 0.7 },
     });
 
     const r = result.response;
     const cand = r?.candidates?.[0];
-
-    // Extract plain text from parts
     const text =
       cand?.content?.parts?.map((p: any) => p?.text ?? "").join("")?.trim() ?? "";
 
-    // Normalize response so the client never deals with raw Vertex JSON
+    if (DEBUG) {
+      console.log("askJesus DEBUG out:", {
+        finishReason: cand?.finishReason,
+        model: (r as any)?.modelVersion,
+        usage: r?.usageMetadata,
+        textPreview: text.slice(0, 120),
+      });
+    }
+
     res.status(200).json({
       text,
       finishReason: cand?.finishReason ?? null,
@@ -50,5 +92,6 @@ export const askJesus = onRequest({ cors: true }, async (req, res) => {
   } catch (e: any) {
     console.error("askJesus error:", e);
     res.status(500).json({ error: e?.message || "Server error" });
+    return;
   }
 });


### PR DESCRIPTION
## Summary
- make askJesus Cloud Run function tolerant of varied request formats and optionally verbose when DEBUG_ASKJESUS=1
- enhance ChatScreen request handling to display detailed server or network errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix functions test` *(fails: Missing script: "test")*
- `npm --prefix functions run build`
- `npx tsc --noEmit`
- `curl -i -X POST "https://askjesus-y54eeumzaq-uc.a.run.app/askJesus" -H "Content-Type: application/json" -d '{"message":"Give me one sentence of gentle, Christ-like guidance about perseverance."}'` *(400 Missing prompt)*
- `curl -i "https://askjesus-y54eeumzaq-uc.a.run.app/askJesus?message=Short%20blessing%20please"` *(405 Method Not Allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b79cd4032c8330b40e9c3daa4292f7